### PR TITLE
[FIX] Permissões do API Gateway + Remoção do StageName

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -80,6 +80,7 @@ Resources:
       StageName: !Ref StageName
       Auth:
         DefaultAuthorizer: TokenAuthorizer
+        EnableIamAuthorizer: true
         Authorizers:
           TokenAuthorizer:
             FunctionArn: !GetAtt TokenAuthorizerFunction.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -77,7 +77,6 @@ Resources:
   ApiGateway:
     Type: AWS::Serverless::HttpApi
     Properties:
-      StageName: !Ref StageName
       Auth:
         DefaultAuthorizer: TokenAuthorizer
         EnableIamAuthorizer: true


### PR DESCRIPTION
A flag `EnableIamAuthorizer` permite que o Gateway crie a IAM Role necessária para invocar o Lambda.

A flag `StageName` foi removida pois ela gera um prefixo no path da URL (`algumaurl.com/prod`), o que causa erros no mapeamento dos Spring.